### PR TITLE
Add check if stdin.setRawMode is a function

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -188,8 +188,12 @@ module.exports.run = function( app_path, brk ) {
 				    })
 				  }
 				});
+
+				// Prevent failure on setRawMode when piping process.stdin
+				if ( typeof process.stdin.setRawMode === "function") {
+					process.stdin.setRawMode( true );
+				}
 				
-				process.stdin.setRawMode(true);
 				process.stdin.resume();
 			})
 		});


### PR DESCRIPTION
Add a check to make sure stdin.setRawMode exists before calling. When
piping the stdin, when for example using Grunt, it won’t fail on the
non-existing setRawMode method anymore.